### PR TITLE
[Fix] 투두 전체 검색 시 조건에 날짜 추가

### DIFF
--- a/src/main/java/com/uplus/bugzerobackend/controller/TodoListController.java
+++ b/src/main/java/com/uplus/bugzerobackend/controller/TodoListController.java
@@ -6,9 +6,11 @@ import com.uplus.bugzerobackend.service.TodoListService;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -42,8 +44,11 @@ public class TodoListController {
 
     // 모든 TodoList 조회
     @GetMapping("/user/{id}")
-    public ResponseEntity<List<TodoListDto>> getAllTodoLists(@PathVariable("id") Integer id) {
-        List<TodoListDto> todoList = todoListService.searchAll(id);
+    public ResponseEntity<List<TodoListDto>> getAllTodoLists(
+            @PathVariable("id") Integer id,
+            @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+
+        List<TodoListDto> todoList = todoListService.searchAll(id, date);
         return ResponseEntity.ok(todoList);
     }
 

--- a/src/main/java/com/uplus/bugzerobackend/mapper/TodoListMapper.java
+++ b/src/main/java/com/uplus/bugzerobackend/mapper/TodoListMapper.java
@@ -11,7 +11,8 @@ public interface TodoListMapper {
     void insert(TodoListDto todoList);  					 // TodoList 추가
     void update(TodoListDto todoList); 						 // TodoList 수정
     TodoListDto search(Integer id);       					 // TodoList 조회
-    List<TodoListDto> searchAll(@Param("userId") Integer id);// 모든 TodoList 조회
+    List<TodoListDto> searchAll(@Param("userId") Integer userId, @Param("date") LocalDate date);
+// 모든 TodoList 조회
     void remove(Integer id);           						 // TodoList 삭제
 
     // 같은 유저가 같은 날짜, 같은 내용의 Todo를 추가했는지 확인

--- a/src/main/java/com/uplus/bugzerobackend/service/TodoListService.java
+++ b/src/main/java/com/uplus/bugzerobackend/service/TodoListService.java
@@ -1,6 +1,8 @@
 package com.uplus.bugzerobackend.service;
 
 import com.uplus.bugzerobackend.dto.TodoListDto;
+
+import java.time.LocalDate;
 import java.util.List;
 
 import org.apache.ibatis.annotations.Param;
@@ -9,6 +11,6 @@ public interface TodoListService {
     void insert(TodoListDto todoList);  // TodoList 추가
     void update(TodoListDto todoList);  // TodoList 수정
     TodoListDto search(Integer id);     // TodoList 조회
-    List<TodoListDto> searchAll(@Param("userId") Integer id);      // 모든 TodoList 조회
+    List<TodoListDto> searchAll(@Param("userId") Integer userId, @Param("date") LocalDate date);      // 모든 TodoList 조회
     void remove(Integer id);         // TodoList 삭제
 }

--- a/src/main/java/com/uplus/bugzerobackend/service/TodoListServiceImpl.java
+++ b/src/main/java/com/uplus/bugzerobackend/service/TodoListServiceImpl.java
@@ -9,6 +9,7 @@ import com.uplus.bugzerobackend.domain.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 
@@ -76,10 +77,10 @@ public class TodoListServiceImpl implements TodoListService {
 
     // 특정 유저의 todo 전체검색
     @Override
-    public List<TodoListDto> searchAll(Integer id) {
-        List<TodoListDto> todoList = todoListDao.searchAll(id);
-        
-        // 빈 리스트 반환 (예외 던지지 않음)
+    public List<TodoListDto> searchAll(Integer userId, LocalDate date) {
+        List<TodoListDto> todoList = todoListDao.searchAll(userId, date);
+
+        // 결과가 null이면 빈 리스트 반환 (예외 발생 X)
         return todoList != null ? todoList : Collections.emptyList();
     }
 

--- a/src/main/resources/mapper/TodoListMapper.xml
+++ b/src/main/resources/mapper/TodoListMapper.xml
@@ -58,6 +58,7 @@
 	        user_id AS userId 
 	    FROM todo_list
 	    WHERE user_id = #{userId}
+	    AND date = #{date}
 	</select>
 
 


### PR DESCRIPTION
## #️⃣연관된 이슈
투두 searchAll에 검색 조건으로 날짜 추가


## 📝작업 내용

- 기존 유저 아이디로만 검색하던 부분을 수정
- 유저 아이디와 날짜 동시에 일치하는 투두만 나오도록 조건 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> _리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요_<br>
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
