### PR TITLE
[Feature] 캘린더 잔디 심기 추가

### DIFF
--- a/src/main/java/com/uplus/bugzerobackend/controller/CalendarController.java
+++ b/src/main/java/com/uplus/bugzerobackend/controller/CalendarController.java
@@ -1,0 +1,51 @@
+package com.uplus.bugzerobackend.controller;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.uplus.bugzerobackend.dto.CalendarRequestDto;
+import com.uplus.bugzerobackend.dto.TodoListDto;
+import com.uplus.bugzerobackend.service.CalendarService;
+import com.uplus.bugzerobackend.service.TodoListService;
+
+import org.springframework.web.bind.annotation.RequestBody;
+
+@RestController
+@RequestMapping("/calendar")
+public class CalendarController {
+
+    private final TodoListService todoListService;
+    private final CalendarService calendarService;
+
+    @Autowired
+    public CalendarController(TodoListService todoListService, CalendarService calendarService) {
+        this.todoListService = todoListService;
+        this.calendarService = calendarService;
+    }
+
+    // 월별 투두 개수 조회
+    @PostMapping("/monthly")
+    public ResponseEntity<Map<String, Object>> getMonthlyProgress(@RequestBody CalendarRequestDto request) {
+        List<TodoListDto> todoLists = todoListService.searchByUserIdAndYearMonth(request.getUserId(), request.getYearMonth());
+
+        Map<String, Object> response = calendarService.processMonthly(todoLists, request);
+        return ResponseEntity.ok(response);
+    }
+
+
+    // 특정 날짜 투두 달성 개수 조회
+    @PostMapping("/daily")
+    public ResponseEntity<Map<String, Object>> getDailyTodoStatus(@RequestBody CalendarRequestDto request) {
+        List<TodoListDto> todoLists = todoListService.searchAll(request.getUserId(), request.getDate());
+
+        Map<String, Object> response = calendarService.processDaily(todoLists, request);
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/com/uplus/bugzerobackend/dto/CalendarRequestDto.java
+++ b/src/main/java/com/uplus/bugzerobackend/dto/CalendarRequestDto.java
@@ -1,0 +1,18 @@
+package com.uplus.bugzerobackend.dto;
+
+import java.time.LocalDate;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor  // 기본 생성자 추가
+public class CalendarRequestDto {
+    private Integer userId;
+    private String yearMonth;    // "2025-01" 형식
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate date;      // "2025-01-01" 형식
+}

--- a/src/main/java/com/uplus/bugzerobackend/dto/TodoListDto.java
+++ b/src/main/java/com/uplus/bugzerobackend/dto/TodoListDto.java
@@ -3,21 +3,23 @@ package com.uplus.bugzerobackend.dto;
 import java.time.LocalDate;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.uplus.bugzerobackend.domain.User;
 
+import jakarta.persistence.Column;
 import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
 
 @Data
-@Getter
-@Setter
 public class TodoListDto {
     private Integer id;           // TodoList의 고유 ID
-    private LocalDate date;    // 날짜 추가
-    private String content;    // 할 일 내용
-    private boolean isMission; // 미션 여부 (필드명 수정)
-    private boolean isChecked; // 체크 여부
+    private LocalDate date;    	  // 날짜 추가
+    private String content;    	  // 할 일 내용
+    @Column(name = "is_checked")  // 컬럼명 매핑
+    private boolean checked;
+    @Column(name = "is_mission")
+    private boolean mission;
     private String link;       // 관련 링크
     private Integer userId;    // userId 필드 추가
     

--- a/src/main/java/com/uplus/bugzerobackend/mapper/TodoListMapper.java
+++ b/src/main/java/com/uplus/bugzerobackend/mapper/TodoListMapper.java
@@ -11,9 +11,9 @@ public interface TodoListMapper {
     void insert(TodoListDto todoList);  					 // TodoList 추가
     void update(TodoListDto todoList); 						 // TodoList 수정
     TodoListDto search(Integer id);       					 // TodoList 조회
-    List<TodoListDto> searchAll(@Param("userId") Integer userId, @Param("date") LocalDate date);
-// 모든 TodoList 조회
+    List<TodoListDto> searchAll(@Param("userId") Integer userId, @Param("date") LocalDate date); // 모든 TodoList 조회
     void remove(Integer id);           						 // TodoList 삭제
+    List<TodoListDto> findByUserIdAndYearMonth(@Param("userId") Integer userId, @Param("yearMonth") String yearMonth); //년-월별 투두조회
 
     // 같은 유저가 같은 날짜, 같은 내용의 Todo를 추가했는지 확인
     TodoListDto searchByUserAndDateAndContent(

--- a/src/main/java/com/uplus/bugzerobackend/service/CalendarService.java
+++ b/src/main/java/com/uplus/bugzerobackend/service/CalendarService.java
@@ -1,0 +1,93 @@
+package com.uplus.bugzerobackend.service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import com.uplus.bugzerobackend.dto.CalendarRequestDto;
+import com.uplus.bugzerobackend.dto.TodoListDto;
+
+@Service
+public class CalendarService {
+
+    // 공통 진행률 계산 함수
+    private Map<Integer, Double> processProgress(List<TodoListDto> todoLists) {
+        Map<Integer, Double> scoreMap = new HashMap<>();
+        Map<Integer, Double> totalScoreMap = new HashMap<>();
+
+        for (TodoListDto todo : todoLists) {
+            int day = todo.getDate().getDayOfMonth();
+            double weight = todo.isMission() ? 1.5 : 1.0;
+            double score = todo.isChecked() ? weight : 0.0;
+
+            scoreMap.put(day, scoreMap.getOrDefault(day, 0.0) + score);
+            totalScoreMap.put(day, totalScoreMap.getOrDefault(day, 0.0) + weight);
+        }
+
+        Map<Integer, Double> progressMap = new HashMap<>();
+        for (int day : totalScoreMap.keySet()) {
+            double total = totalScoreMap.get(day);
+            double progress = (total > 0) ? (scoreMap.getOrDefault(day, 0.0) / total) * 100 : 0.0;
+            progressMap.put(day, progress);
+        }
+
+        return progressMap;
+    }
+
+    // 년-월별 투두 진행률 계산
+    public Map<String, Object> processMonthly(List<TodoListDto> todoLists, CalendarRequestDto request) {
+        System.out.println("=== [디버깅] 요청 정보 ===");
+        System.out.println("userId: " + request.getUserId());
+        System.out.println("yearMonth: " + request.getYearMonth());
+
+        Map<Integer, Double> progressMap = processProgress(todoLists);
+
+        // 1일부터 31일까지 기본값 0.0으로 초기화
+        Map<Integer, Double> fullProgressMap = new HashMap<>();
+        for (int i = 1; i <= 31; i++) {
+            fullProgressMap.put(i, 0.0);
+        }
+
+        // 기존 진행률 데이터를 fullProgressMap에 반영
+        for (Map.Entry<Integer, Double> entry : progressMap.entrySet()) {
+            fullProgressMap.put(entry.getKey(), entry.getValue());
+        }
+
+        System.out.println("\n=== [디버깅] 최종 진행률 ===");
+        System.out.println("progressMap: " + fullProgressMap);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("userId", request.getUserId());
+        response.put("score", fullProgressMap);
+
+        return response;
+    }
+
+
+    // 특정 날짜 투두 진행률 계산
+    public Map<String, Object> processDaily(List<TodoListDto> todoLists, CalendarRequestDto request) {
+        System.out.println("=== [디버깅] 요청 정보 ===");
+        System.out.println("userId: " + request.getUserId());
+        System.out.println("date: " + request.getDate());
+
+        Map<Integer, Double> progressMap = processProgress(todoLists);
+        int day = request.getDate().getDayOfMonth();
+        double score = progressMap.getOrDefault(day, 0.0);
+
+        System.out.println("\n=== [디버깅] 특정 날짜 진행률 ===");
+        System.out.println("progressMap: " + progressMap);
+        System.out.println("score: " + score);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("userId", request.getUserId());
+        response.put("date", request.getDate());
+        response.put("score", score);
+
+        return response;
+    }
+}

--- a/src/main/java/com/uplus/bugzerobackend/service/TodoListService.java
+++ b/src/main/java/com/uplus/bugzerobackend/service/TodoListService.java
@@ -14,6 +14,6 @@ public interface TodoListService {
     TodoListDto search(Integer id);     // TodoList 조회
     List<TodoListDto> searchAll(@Param("userId") Integer userId, @Param("date") LocalDate date);      // 모든 TodoList 조회
     void remove(Integer id);         // TodoList 삭제
-
+    List<TodoListDto> searchByUserIdAndYearMonth(@Param("userId") Integer userId, @Param("yearMonth") String yearMonth);
     void checkTodoList(Integer id);
 }

--- a/src/main/java/com/uplus/bugzerobackend/service/TodoListServiceImpl.java
+++ b/src/main/java/com/uplus/bugzerobackend/service/TodoListServiceImpl.java
@@ -96,6 +96,15 @@ public class TodoListServiceImpl implements TodoListService {
         return todoList != null ? todoList : Collections.emptyList();
     }
 
+    //특정 유저의 특정 년-월 투두 검색
+    @Override
+    public List<TodoListDto> searchByUserIdAndYearMonth(Integer userId, String yearMonth) {
+        List<TodoListDto> todoList = todoListDao.findByUserIdAndYearMonth(userId, yearMonth);
+        
+        // 결과가 null이면 빈 리스트 반환 (예외 발생 X)
+        return todoList != null ? todoList : Collections.emptyList();
+    }
+    
     // todo 삭제
     @Override
     public void remove(Integer id) {

--- a/src/main/resources/mapper/TodoListMapper.xml
+++ b/src/main/resources/mapper/TodoListMapper.xml
@@ -30,6 +30,17 @@
         AND content = #{content}
     </select>
 
+	<select id="findByUserIdAndYearMonth" resultType="com.uplus.bugzerobackend.dto.TodoListDto">
+	    SELECT user_id AS userId,
+           date,
+           content,
+           is_mission As mission, 
+	        is_checked AS checked
+	    FROM todo_list
+	    WHERE user_id = #{userId}
+	    AND DATE_FORMAT(date, '%Y-%m') = #{yearMonth}
+	</select>
+	
 	<!-- User를 userId로 조회하는 쿼리 
     <select id="findUserById" resultType="com.uplus.bugzerobackend.todo.model.dto.User">
         SELECT *

--- a/src/main/resources/mapper/TodoListMapper.xml
+++ b/src/main/resources/mapper/TodoListMapper.xml
@@ -9,7 +9,7 @@
 
 	<insert id="insert" parameterType="com.uplus.bugzerobackend.dto.TodoListDto" useGeneratedKeys="true" keyProperty="id">
 	    INSERT INTO todo_list (date, content, is_mission, is_checked, link, user_id)
-	    VALUES (#{date}, #{content}, #{isMission}, #{isChecked}, #{link}, #{userId}) 
+	    VALUES (#{date}, #{content}, #{mission}, #{checked}, #{link}, #{userId}) 
 	</insert>
 
 
@@ -50,8 +50,8 @@
 	        id, 
 	        date, 
 	        content, 
-	        is_mission As isMission, 
-	        is_checked AS isChecked, 
+	        is_mission As mission, 
+	        is_checked AS checked, 
 	        link, 
 	        user_id AS userId 
 	    FROM todo_list


### PR DESCRIPTION
## #️⃣연관된 이슈
#3 


## 📝작업 내용

- 투두 리스트 달성여부 월별 조회, 일별 조회

- 월별 조회 (calendar/monthly)
   userId,yearMonth 전달
   1~31일까지의 유저 투두 달성 여부를 출력
   기본값은 0.0, 값이 있는 곳만 변경됨 (백분율)

- 일별 조회 (calendar/daily)
   userId, date 전달
   유저의 지정 날짜에 해당하는 투두 달성 여부를 출력
   투두 달성 체크 시 실시간으로 색 변경 위해 추가함


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> _리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요_<br>
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
